### PR TITLE
Fix cached paging not working properly

### DIFF
--- a/mage2gen/snippets/model.py
+++ b/mage2gen/snippets/model.py
@@ -36,12 +36,12 @@ class InterfaceMethod(Phpmethod):
 
 class ModelSnippet(Snippet):
 	description = """
-	Model is used to create a easie CRUD interface to the database 
+	Model is used to create a easie CRUD interface to the database
 
 	- **Model ame:** The name of the model, the table name wil be <module_name>_<model_name>.
 	- **Field name:** The name of the database table field.
 	- **Field type:** The type of database field.
-	- **Adminhtml grid:** Add this field to the adminhtml grid layout  
+	- **Adminhtml grid:** Add this field to the adminhtml grid layout
 
 	**Model ID field**:	The snippet will auto add the model id field to the database table, the field name is <model_name>_id.
 	"""
@@ -273,14 +273,14 @@ class ModelSnippet(Snippet):
 		))
 		model_class.add_method(Phpmethod('getDataModel', access=Phpmethod.PUBLIC,
 			body="""${variable}Data = $this->getData();
-			
+
 			${variable}DataObject = $this->{variable}DataFactory->create();
 			$this->dataObjectHelper->populateWithArray(
 			    ${variable}DataObject,
 			    ${variable}Data,
 			    {variable_upper}Interface::class
 			);
-			
+
 			return ${variable}DataObject;
 			""".format(variable=model_name.lower(), variable_upper=model_name_capitalized),
 			docstring=[
@@ -386,15 +386,15 @@ class ModelSnippet(Snippet):
 					    $storeId = $this->storeManager->getStore()->getId();
 					    ${variable}->setStoreId($storeId);
 					}} */
-					
+
 					${variable}Data = $this->extensibleDataObjectConverter->toNestedArray(
 					    ${variable},
 					    [],
 					    \{data_interface}::class
 					);
-					
+
 					${variable}Model = $this->{variable}Factory->create()->setData(${variable}Data);
-					
+
 					try {{
 					    $this->resource->save(${variable}Model);
 					}} catch (\Exception $exception) {{
@@ -421,22 +421,22 @@ class ModelSnippet(Snippet):
 		model_repository_class.add_method(Phpmethod('getList', access=Phpmethod.PUBLIC,
 			params=['\Magento\Framework\Api\SearchCriteriaInterface $criteria'],
 			body="""$collection = $this->{variable}CollectionFactory->create();
-			
+
 					$this->extensionAttributesJoinProcessor->process(
 					    $collection,
 					    \{data_interface}::class
 					);
-			
+
 					$this->collectionProcessor->process($criteria, $collection);
-					
+
 					$searchResults = $this->searchResultsFactory->create();
 					$searchResults->setSearchCriteria($criteria);
-					
+
 					$items = [];
 					foreach ($collection as $model) {{
 					    $items[] = $model->getDataModel();
 					}}
-					
+
 					$searchResults->setItems($items);
 					$searchResults->setTotalCount($collection->getSize());
 					return $searchResults;
@@ -649,6 +649,9 @@ class ModelSnippet(Snippet):
 		# create components.xml
 		data_source_xml = Xmlnode('dataSource', attributes={'name': data_source_id, 'component': 'Magento_Ui/js/grid/provider'}, nodes=[
 			Xmlnode('settings', nodes=[
+				Xmlnode('storageConfig', nodes=[
+					Xmlnode('param', attributes={'name': 'indexField', 'xsi:type': 'string'} node_text=model_id)
+				]),
 				Xmlnode('updateUrl', attributes={'path': 'mui/index/render'})
 			]),
 			Xmlnode('aclResource', node_text='{}_{}::{}'.format(self._module.package, self._module.name, model_name)),
@@ -1103,7 +1106,7 @@ class ModelSnippet(Snippet):
 					        $this->messageManager->addErrorMessage(__('This {model_name} no longer exists.'));
 					        return $resultRedirect->setPath('*/*/');
 					    }}
-									
+
 					    $model->setData($data);
 
 					    try {{


### PR DESCRIPTION
A setting is missing in the dataSource configuration when the indexField is not equal to `entity_id`. When paging through a grid, the results are cached by their IDs. Consequently, the resolving of the IDs will result unwanted behavior.

To set the indexField for the `Magento_Ui/js/grid/provider` component, the following setting has to be set:

``` xml
<dataSource component="Magento_Ui/js/grid/provider" name="...">
  <settings>
    <storageConfig>
      <param name="indexField" xsi:type="string">...</param>
    </storageConfig>
    <updateUrl path="mui/index/render"/>
  </settings>
</dataSource>
```