### PR TITLE
Set source_model for boolean product attribute

### DIFF
--- a/mage2gen/snippets/productattribute.py
+++ b/mage2gen/snippets/productattribute.py
@@ -95,6 +95,8 @@ class ProductAttributeSnippet(Snippet):
 			options_php_array = '[\n' + ',\n'.join(x.strip() for x in options_array) + '\n]'
 			self.add_source_model(attribute_code_capitalized, options_php_array, extra_params.get('used_in_product_listing', False))
 			options_php_array_string = "''"
+		elif frontend_input == 'boolean' :
+			source_model = "\{}\{}\Magento\Eav\Model\Entity\Attribute\Source\Boolean\{}::class".format(self._module.package, self._module.name, attribute_code_capitalized)
 		else:
 			source_model = "''"
 

--- a/mage2gen/snippets/productattribute.py
+++ b/mage2gen/snippets/productattribute.py
@@ -95,7 +95,7 @@ class ProductAttributeSnippet(Snippet):
 			options_php_array = '[\n' + ',\n'.join(x.strip() for x in options_array) + '\n]'
 			self.add_source_model(attribute_code_capitalized, options_php_array, extra_params.get('used_in_product_listing', False))
 			options_php_array_string = "''"
-		elif frontend_input == 'boolean' :
+		elif frontend_input == 'boolean':
 			source_model = "\{}\{}\Magento\Eav\Model\Entity\Attribute\Source\Boolean\{}::class".format(self._module.package, self._module.name, attribute_code_capitalized)
 		else:
 			source_model = "''"


### PR DESCRIPTION
Hi,

As commented in tickets:

* https://github.com/Mage2Gen/Mage2Gen/issues/346
* https://github.com/Mage2Gen/Mage2Gen/issues/327
* https://github.com/Mage2Gen/Mage2Gen/issues/309

The source_model of the boolean attribute shouldn't be empty, but Magento\Eav\Model\Entity\Attribute\Source\Boolean

I've modified the snippet adding this specific condition.