### PR TITLE
Change frontend input of varchar to text

### DIFF
--- a/mage2gen/snippets/customerattribute.py
+++ b/mage2gen/snippets/customerattribute.py
@@ -42,7 +42,7 @@ class CustomerAttributeSnippet(Snippet):
 	]
 	
 	FRONTEND_INPUT_VALUE_TYPE = {
-        "text":"varchar",
+        "text":"text",
         "textarea":"text",
         "date":"date",
         "boolean":"int",


### PR DESCRIPTION
When creating a customer attribute and choosing 'Frontend Input' -> 'Text Field', the eav_attribute 'frontend_input' is set to varchar. This gives the following error on the customer edit page:

Argument 2 passed to Magento\Framework\View\Element\UiComponentFactory::argumentsResolver() must be of the type array, null given,

NOTE: I'm guessing this also goes for Multiselect (should be frontend_input=multiselect), Select (should be frontend_input=select) & Boolean (should be frontend_input=boolean)