### PR TITLE
fix(#377): proper source model in a boolean product attributes

### DIFF
--- a/mage2gen/snippets/productattribute.py
+++ b/mage2gen/snippets/productattribute.py
@@ -96,7 +96,7 @@ class ProductAttributeSnippet(Snippet):
 			self.add_source_model(attribute_code_capitalized, options_php_array, extra_params.get('used_in_product_listing', False))
 			options_php_array_string = "''"
 		elif frontend_input == 'boolean':
-			source_model = "\{}\{}\Magento\Eav\Model\Entity\Attribute\Source\Boolean\{}::class".format(self._module.package, self._module.name, attribute_code_capitalized)
+			source_model = "'Magento\Eav\Model\Entity\Attribute\Source\Boolean'"
 		else:
 			source_model = "''"
 


### PR DESCRIPTION
This fixes #337 providing proper source model for a boolean product attribute generator