### PR TITLE
Change default ID field of model to `int` instead of `smallint`

### DIFF
--- a/mage2gen/snippets/model.py
+++ b/mage2gen/snippets/model.py
@@ -108,7 +108,7 @@ class ModelSnippet(Snippet):
 		column_nodes = []
 		# add model id field
 		column_nodes.append(Xmlnode('column', attributes={
-			'xsi:type': "{}".format('smallint'),
+			'xsi:type': "{}".format('int'),
 			'name': "{}".format(model_id),
 			'padding': "{}".format('6'),
 			'unsigned': "{}".format('true'),
@@ -192,7 +192,7 @@ class ModelSnippet(Snippet):
 				'comment': "{} Table".format(model_table)
 			}, nodes=[
 				Xmlnode('column', attributes={
-					'xsi:type': "{}".format('smallint'),
+					'xsi:type': "{}".format('int'),
 					'name': "{}".format(model_id),
 					'padding': "{}".format('6'),
 					'unsigned': "{}".format('true'),


### PR DESCRIPTION
An ID field should support in default larger repositories. `smallint` only goes to 65.535 unsigned.

For smaller tables, the speed/resource benefit of smallint is also miniscule.