### PR TITLE
[BUGFIX][BACI-567] New model snippet still uses _get()

### DIFF
--- a/mage2gen/snippets/model.py
+++ b/mage2gen/snippets/model.py
@@ -312,7 +312,7 @@ class ModelSnippet(Snippet):
 
 		model_class.add_method(Phpmethod('get' + model_id_capitalized,
 			docstring=['@inheritDoc'],
-			body="""return $this->_get({});
+			body="""return $this->getData({});
 			""".format('self::'+model_id.upper()),
 		))
 
@@ -325,7 +325,7 @@ class ModelSnippet(Snippet):
 
 		model_class.add_method(Phpmethod('get' + field_name_capitalized,
 			docstring=['@inheritDoc'],
-			body="""return $this->_get({});
+			body="""return $this->getData({});
 			""".format('self::' + field_name.upper()),
 		))
 


### PR DESCRIPTION
[BUGFIX][BACI-567] New model snippet still uses _get() which doesn't work for extends of \Magento\Framework\Model\AbstractModel. Fixed getter function implementations by replacing it with the existing getData().

I can release januari 10th; but feel free to quick release if you feel like it :-)