### PR TITLE
fix minimum controller actionname length

### DIFF
--- a/mage2gen/snippets/controller.py
+++ b/mage2gen/snippets/controller.py
@@ -274,7 +274,7 @@ return $this->http->setBody(
 	def params(cls):
 		return [
 			SnippetParam(name='frontname', required=False, description='On empty uses module name in lower case',
-				regex_validator= r'^[a-z]{1}\w+$',
+				regex_validator= r'^[a-z]{1}\w{2,}$',
 				error_message='Only lowercase alphanumeric and underscore characters are allowed, and need to start with a alphabetic character.',
 				repeat=True),
 			SnippetParam(name='section', required=True, default='index',


### PR DESCRIPTION
should fix https://github.com/Mage2Gen/Mage2Gen/issues/400 (can't test it)